### PR TITLE
[FEATURE] Pass form array to afterParseFormEvent

### DIFF
--- a/Classes/Event/AfterParseFormEvent.php
+++ b/Classes/Event/AfterParseFormEvent.php
@@ -9,9 +9,15 @@ final class AfterParseFormEvent
      */
     private $items;
 
-    public function __construct(array $items)
+    /**
+     * @var array
+     */
+    private $form;
+
+    public function __construct(array $items, array $form)
     {
         $this->items = $items;
+        $this->form = $form;
     }
 
     public function getItems(): array
@@ -30,5 +36,15 @@ final class AfterParseFormEvent
             throw new \InvalidArgumentException('Item already exists', 1641731370528);
         }
         $this->items[$identifier] = $value;
+    }
+
+    public function getForm(): array
+    {
+        return $this->form;
+    }
+
+    public function setForm(array $form): void
+    {
+        $this->form = $form;
     }
 }

--- a/Classes/Parser/FormDefinitionLabelsParser.php
+++ b/Classes/Parser/FormDefinitionLabelsParser.php
@@ -92,7 +92,7 @@ class FormDefinitionLabelsParser
         //     $items[$id] = '';
         // }
 
-        $event = new AfterParseFormEvent($items);
+        $event = new AfterParseFormEvent($items, $form);
         $this->dispatcher->dispatch($event);
         return $event->getItems();
     }


### PR DESCRIPTION
Thank you for your extension. We are using the afterParseFormEvent event to add additional properties to the user interface. To avoid having to re-initialize everything in the event listener, I have extended the event slightly and added the form array. This makes it possible to extract additional fields directly from the array in the event listener.

```
$finishers = array_filter($form['finishers'], function ($finisher) {
    return $finisher['identifier'] === 'EmailToSender';
});