### PR TITLE
Fix dependency injection for TranslationController

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -31,6 +31,9 @@ services:
     factory: ['@TYPO3\CMS\Core\Configuration\ExtensionConfiguration', 'get']
     arguments: ['form_translator', 'typo3LanguageWhitelist']
 
+  R3H6\FormTranslator\Controller\TranslationController:
+    public: true
+
   R3H6\FormTranslator\Service\LibreTranslateTranslationService:
     arguments:
       $host: '@extensionconfiguration.form_translator.libreTranslate.host'


### PR DESCRIPTION
Hi,
while testing the extension under TYPO3 version 12.4, I noticed that clicking on the translation button results in the following error:
```
TYPO3 [CRITICAL] request="2c0bcc1f4f846" component="TYPO3.CMS.Core.Error.DebugExceptionHandler": Core: Exception handler (WEB: BE): ArgumentCountError, code #0, file /var/www/html/vendor/r3h6/form-translator/Classes/Controller/TranslationController.php, line 20: Too few arguments to function R3H6\FormTranslator\Controller\TranslationController::__construct(), 0 passed in /var/www/html/vendor/typo3/cms-core/Classes/Utility/GeneralUtility.php on line 2994 and exactly 3 expected...
```

To fix this, I added the following to `Services.yaml`:
```
R3H6\FormTranslator\Controller\TranslationController:
    public: true
```

Best regards
Digi92
