### PR TITLE
Add a feature to hide the translation button when the feature is not configured

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -56,11 +56,18 @@ class FormController extends ActionController
             $language->getTitle(),
         ]);
 
+        try {
+            $translationServiceEnabled = empty($this->extensionConfiguration->get('form_translator', 'libreTranslate/host')) === false;
+        } catch (\Exception $e) {
+            $translationServiceEnabled = false;
+        }
+
         $moduleTemplate = $this->initializeModuleTemplate($title);
         $moduleTemplate->assign('title', $title);
         $moduleTemplate->assign('items', $this->formService->getItems($persistenceIdentifier, $language));
         $moduleTemplate->assign('language', $language);
         $moduleTemplate->assign('persistenceIdentifier', $persistenceIdentifier);
+        $moduleTemplate->assign('translationServiceEnabled', $translationServiceEnabled);
 
         $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
         $buttonBar->addButton(

--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -15,6 +15,7 @@ use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -32,6 +33,7 @@ class FormController extends ActionController
         protected ModuleTemplateFactory $moduleTemplateFactory,
         protected IconFactory $iconFactory,
         protected PageRenderer $pageRenderer,
+        protected ExtensionConfiguration $extensionConfiguration
     ) {}
 
     public function indexAction(): ResponseInterface

--- a/Resources/Private/Templates/Form/Localize.html
+++ b/Resources/Private/Templates/Form/Localize.html
@@ -24,9 +24,16 @@
                      <small class="form-text text-muted">{item.identifier}</small>
                   </td>
                   <td>
-                     <button class="btn btn-sm" tabindex="-1" type="button" data-translate-to="{language.typo3Language}" data-source="#Source{i.index}" data-target="#Target{i.index}">
-                        <core:icon identifier="actions-translate" size="small" />
-                     </button>
+                      <f:if condition="{translationServiceEnabled}">
+                          <f:then>
+                              <button class="btn btn-sm" tabindex="-1" type="button" data-translate-to="{language.typo3Language}" data-source="#Source{i.index}" data-target="#Target{i.index}">
+                                  <core:icon identifier="actions-translate" size="small" />
+                              </button>
+                          </f:then>
+                          <f:else>
+                              <core:icon identifier="actions-arrow-right" size="small" />
+                          </f:else>
+                      </f:if>
                   </td>
                   <td>
                      <f:form.hidden name="items[{i.index}][identifier]" value="{item.identifier}" />


### PR DESCRIPTION
Hi, 
I have expanded Localize.html, so that the Translation button is only displayed if the feature is configured.
If it is not configured, the icon is displayed instead of the button: [actions-arrow-right](https://typo3.github.io/TYPO3.Icons/icons/actions/actions-arrow-right.html)

Is that acceptable to you?

Best regards
Digi92
