### PR TITLE
Update PHP version requirement to ^8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": ">= 8.1 < 8.4",
+		"php": "^8",
 		"softcreatr/jsonpath": "^0.9",
 		"typo3/cms-core": "^12.4 || ^13.4",
 		"typo3/cms-form": "^12.4 || ^13.4"


### PR DESCRIPTION
Since the extension is also compatible with PHP 8.4 and probably also with 8.5, the dependency should be adjusted to make installation easier.