### PR TITLE
Fixes an error in the TYPO3 Forms backend preview while editing forms.

### DIFF
--- a/Classes/Hooks/TranslateValidationErrorMessages.php
+++ b/Classes/Hooks/TranslateValidationErrorMessages.php
@@ -39,7 +39,7 @@ final class TranslateValidationErrorMessages
             '<element-identifier>',
             '<error-code>',
         ], [
-            $form->getRenderingOptions()['_originalIdentifier'],
+            $form->getRenderingOptions()['_originalIdentifier'] ?? $form->getIdentifier(),
             $renderable->getIdentifier(),
             $message['code'],
         ], '<form-identifier>.validation.error.<element-identifier>.<error-code>');
@@ -62,6 +62,9 @@ final class TranslateValidationErrorMessages
     private function getLanguageService(): LanguageService
     {
         $siteLanguage = $this->getRequest()->getAttribute('language');
+        if (!$siteLanguage) {
+            return $this->languageServiceFactory->create('en');
+        }
         return $this->languageServiceFactory->createFromSiteLanguage($siteLanguage);
     }
 


### PR DESCRIPTION
Hi
in some backend contexts the request doesn’t seem to provide a language attribute and the form rendering options may miss _originalIdentifier (I’m not entirely sure why this happens), so this change adds safe fallbacks to prevent the preview from breaking.

Best regards
Digi92